### PR TITLE
Fix broken URL in homepage

### DIFF
--- a/packages/web-app/src/pages/Governance/index.tsx
+++ b/packages/web-app/src/pages/Governance/index.tsx
@@ -29,7 +29,7 @@ const GovernancePage = () => {
           </a>{" "}
           and{" "}
           <a
-            href="https://https://opensea.io/collection/lootproject"
+            href="https://opensea.io/collection/lootproject"
             target="_blank"
           >
             Opensea


### PR DESCRIPTION
small typo in the URL on the homepage directs to broken link